### PR TITLE
Fork mousetrap to fix listener leak

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7498,9 +7498,8 @@
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "mousetrap": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
-      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA=="
+      "version": "github:scottwittenburg/mousetrap#3f4ba0009f1c5eda9e37177f8da5963739314ccd",
+      "from": "github:scottwittenburg/mousetrap#fix-listener-leak"
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "@girder/components": "git+https://github.com/girder/girder_web_components.git#v2.2.6",
     "bluebird": "^3.5.5",
     "itk": "^9.1.1",
-    "mousetrap": "~1.6.2",
+    "mousetrap": "scottwittenburg/mousetrap#fix-listener-leak",
     "vtk.js": "14.16.5",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.5.1",

--- a/client/src/vue-utilities/v-mousetrap/index.js
+++ b/client/src/vue-utilities/v-mousetrap/index.js
@@ -31,7 +31,7 @@ function bind(el, value, bindElement) {
 }
 
 function unbind(el) {
-  el.mousetrap.reset();
+  el.mousetrap.destroy();
 }
 
 export default function install(Vue) {


### PR DESCRIPTION
It seems the issue which affected our performance so badly, with over 100K event listeners attached to the DOM after scanning through many images, was not caused by `v-mousetrap` from the `vue-utilities` library, but rather the underlying `mousetrap` library itself.

This [issue](https://github.com/ccampbell/mousetrap/issues/427) in `mousetrap` was identified and this [PR](https://github.com/ccampbell/mousetrap/pull/428) to fix it were submitted over two years ago, but neither have received any attention from the maintainer since that time.  In fact, the maintainer of that project may have moved on to other things, as the last accepted PR was around a year ago.

To verify the fix mentioned above, which looks to me like it should solve the problem, I pushed it to my fork of `mousetrap` and have tried it out here.  It works as advertised, so we could take this approach for now in order to solve our performance problem.  However, we may want to look for another approach to key binding, since the `mousetrap` project may no longer be maintained.