### PR TITLE
Redirect to the girder forgot password dialog

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapMutations, mapActions } from "vuex";
 import { GirderAuthentication } from "@girder/components/src";
+import { GIRDER_URL } from "../constants";
 
 export default {
   name: "Login",
@@ -16,7 +17,10 @@ export default {
   },
   methods: {
     ...mapMutations(["setCurrentUser", "setSessionStatus"]),
-    ...mapActions(["startLoginMonitor"])
+    ...mapActions(["startLoginMonitor"]),
+    forgotPassword() {
+      window.location.href = `${GIRDER_URL}#?dialog=resetpassword`;
+    }
   },
   watch: {
     "girderRest.user"(user) {
@@ -34,7 +38,7 @@ export default {
 <template>
   <v-container>
     <v-dialog :value="userDialog" persistent max-width="500px">
-      <GirderAuthentication :register="true" />
+      <GirderAuthentication :register="true" @forgotpassword="forgotPassword" />
     </v-dialog>
   </v-container>
 </template>


### PR DESCRIPTION
When a user clicks on the `Forgot Password` button in the GWC Login widget, redirect them to the Forgot Password dialog in the Girder client.